### PR TITLE
Temporary solution for loosing events after kafka partition rebalancing:

### DIFF
--- a/src/main/java/com/pinterest/secor/uploader/Uploader.java
+++ b/src/main/java/com/pinterest/secor/uploader/Uploader.java
@@ -138,6 +138,11 @@ public class Uploader {
         if (startOffset == srcPath.getOffset()) {
             return;
         }
+
+        if (System.getProperty("exitOnTrim") != null)
+            // trim works incorrectly, so I exit the app to restart container and start everything from scratch
+            System.exit(43);
+
         FileReader reader = null;
         FileWriter writer = null;
         LogFilePath dstPath = null;
@@ -233,10 +238,6 @@ public class Uploader {
                 LOG.debug("previous committed offset count {} is lower than committed offset {} is lower than or equal to last seen offset {}. " +
                                 "Trimming files in topic {} partition {}",
                         oldOffsetCount, newOffsetCount, lastSeenOffset, topicPartition.getTopic(), topicPartition.getPartition());
-
-                if (System.getProperty("exitOnTrim") != null)
-                    // trim works incorrectly, so I exit the app to restart container and start everything from scratch
-                    System.exit(43);
 
                 // There was a rebalancing event and someone committed an offset lower than that
                 // of the current message.  We need to trim local files.

--- a/src/main/java/com/pinterest/secor/uploader/Uploader.java
+++ b/src/main/java/com/pinterest/secor/uploader/Uploader.java
@@ -139,9 +139,11 @@ public class Uploader {
             return;
         }
 
-        if (System.getProperty("exitOnTrim") != null)
+        if (System.getProperty("exitOnTrim") != null) {
             // trim works incorrectly, so I exit the app to restart container and start everything from scratch
+            LOG.warn("Force exit the app to restart container!");
             System.exit(43);
+        }
 
         FileReader reader = null;
         FileWriter writer = null;


### PR DESCRIPTION
Move exit into trim method after checking that file have to be trimmed.
Secor goes into this branch on during the first file upload with startOffset = offset of the file